### PR TITLE
Date added to -a tag example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You need to have [Rust](https://www.rust-lang.org/) installed, version 2018 or a
 ## Getting started
 Set the APOD image as wallpaper: `nasa-wallpaper -a`
 
-Set the APOD image of the 27th March 1999: `nasa-wallpaper -a`
+Set the APOD image of the 27th March 1999: `nasa-wallpaper -a 1999-3-27`
 
 Set a random image from the NASA Image Library: `nasa-wallpaper -n`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use clap::{App, Arg};
 use colored::*;
 use rand::Rng;
 use std::fmt;
+use std::process;
 
 const LICENSE_TEXT: &str = "
    Copyright 2019 David Población
@@ -171,7 +172,8 @@ fn get_nasa_image(
         .as_usize()
         .expect("Could not convert to usize");
     if *num_hits == 0 {
-        panic!("Couldn't find the file you're looking for. Try another tag.");
+        println!("Couldn't find the file you're looking for. Try another tag.");
+        process::exit(0x0100);
     }
     let pages = {
         if (*num_hits / 100) - 1 <= 100 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn get_nasa_image(
         .as_usize()
         .expect("Could not convert to usize");
     if *num_hits == 0 {
-        panic!("No items were found :(")
+        panic!("Couldn't find the file you're looking for. Try another tag.");
     }
     let pages = {
         if (*num_hits / 100) - 1 <= 100 {
@@ -189,7 +189,7 @@ fn get_nasa_image(
             .text()
             .unwrap(),
     )
-    .unwrap();
+    .unwrap(); 
     // Get a random index from the page selected
     let index = {
         if *num_hits < 7 {


### PR DESCRIPTION
This should close #7 Major change to how `-t` flag handles a no result. The function now instructs the user to try another tag before exiting instead of calling `panic!` and a very small change to README.md example for retrieving APOD from specific date didn't include the correct syntax. I've just added the code to match the example given.